### PR TITLE
[#9] RestControllerAdvice를 이용한 전역 예외 처리 설정

### DIFF
--- a/src/main/java/com/programmers/ticketparis/common/dto/ErrorResponse.java
+++ b/src/main/java/com/programmers/ticketparis/common/dto/ErrorResponse.java
@@ -1,0 +1,36 @@
+package com.programmers.ticketparis.common.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.programmers.ticketparis.common.exception.ExceptionRule;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+	private final LocalDateTime timestamp = LocalDateTime.now();
+	private final String code;
+	private final String message;
+	private List<String> data;
+
+	protected ErrorResponse(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	protected ErrorResponse(String code, String message, List<String> data) {
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static ErrorResponse of(ExceptionRule rule) {
+		return new ErrorResponse(rule.name(), rule.getMessage());
+	}
+
+	public static ErrorResponse of(ExceptionRule rule, List<String> rejectedValues) {
+		return new ErrorResponse(rule.name(), rule.getMessage(), rejectedValues);
+	}
+}

--- a/src/main/java/com/programmers/ticketparis/common/exception/BusinessException.java
+++ b/src/main/java/com/programmers/ticketparis/common/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.programmers.ticketparis.common.exception;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ExceptionRule rule;
+	private final List<String> rejectedValues;
+
+	protected BusinessException(ExceptionRule rule, List<String> rejectedValues) {
+		super(rule.getMessage());
+		this.rule = rule;
+		this.rejectedValues = rejectedValues;
+	}
+}

--- a/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
@@ -1,0 +1,18 @@
+package com.programmers.ticketparis.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionRule {
+
+	NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI에 해당하는 리소스를 찾을 수 없음"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP Method 요청 발생"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "기타 서버 내부 에러 발생");
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionRule {
 
-	NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URI에 해당하는 리소스를 찾을 수 없음"),
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "사용자 입력 유효성 검사 실패"),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URL에 해당하는 리소스를 찾을 수 없음"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP Method 요청 발생"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "기타 서버 내부 에러 발생");
 

--- a/src/main/java/com/programmers/ticketparis/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/programmers/ticketparis/common/exception/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-		log.error("{} : 예상 메서드 - {}, 실제 메서드 - {}", METHOD_NOT_ALLOWED.getMessage(), e.getSupportedMethods(), e.getMethod(), e);
+		log.error("{} : 지원 메서드 - {}, 실제 요청 메서드 - {}", METHOD_NOT_ALLOWED.getMessage(), e.getSupportedMethods(), e.getMethod(), e);
 		ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
 
 		return ResponseEntity.status(METHOD_NOT_ALLOWED.getStatus()).body(response);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,15 @@ spring:
   profiles:
     default: local
 
+  # 요청 URI로 리소스를 찾을 수 없는 경우 NoHandlerFoundException 예외 발생 시키기
+  mvc:
+    throw-exception-if-no-handler-found: true
+
+  # ResourceHttpRequestHandler에 대한 매핑 끄기
+  web:
+    resources:
+      add-mappings: false
+
 # MyBatis 설정
 mybatis:
   # 마이바티스에서 타입 정보를 사용할 때 패키지 이름을 적어줘야하는데, 여기에 명시하면 패키지 이름 생략 가능


### PR DESCRIPTION
## 👨‍💻 작업 사항

**이슈 #9**  

<br>

**Tasks**
- [x] 모든 비즈니스 예외의 공통 조상인 BusinessException 생성
- [x] RestControllerAdvice를 이용한 전역 예외처리 설정
  - [x] `400 BAD REQUEST` - 사용자 입력이 잘못되어 Bean Validation에서 걸린 경우
  - [x] `404 NOT FOUND` - 존재하지 않는 URL로 요청한 경우
  - [x] `405 METHOD NOT ALLOWED` - 허용되지 않은 Http Method로 요청한 경우
  - [x] `500 INTERNAL SERVER ERROR`  - 기타 예외 처리
- [x] 404 NOT FOUND 예외 처리에 대한 application.yml 설정
- [x] 에러 전용 응답 객체 생성 (ErrorResponse)

<br>

**에러 API 응답 예시**
```json
{
    "timestamp": "2023-09-03T17:41:05.918558",
    "code": "NOT_FOUND",
    "message": "요청한 URL에 해당하는 리소스를 찾을 수 없음",
    "data": null
}
```
- `timestamp` : 서버 시간
- `code` : ExceptionRule에 정의된 객체 name
- `message` : ExceptionRule에 정의된 메시지
- `data` : 사용자 입력, 혹은 비즈니스 로직에서 예외를 발생시키는 원인 값 목록 (원인 값 없이 예외가 발생하는 경우에는 null)

<br>

## 🙏 리뷰어에게
- 각 도메인에서의 예외 클래스(= 비즈니스 예외)를 만들 때는 반드시 BusinessException.java를 상속해주세요.
- 비즈니스 예외에 대해서는 ExceptionRule에 해당 예외를 정의해주세요. (httpstatus, message)