### PR TITLE
[#15] CD Docker down 현상 조치

### DIFF
--- a/.github/workflows/cd-dev-with-docker-compose.yml
+++ b/.github/workflows/cd-dev-with-docker-compose.yml
@@ -62,7 +62,7 @@ jobs:
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_INSTANCE_HOST }}
-          port: ${{ secrets.EC2_INSTANCrmE_PORT }}
+          port: ${{ secrets.EC2_INSTANCE_PORT }}
           username: ${{ secrets.EC2_INSTANCE_USERNAME }}
           key: ${{ secrets.EC2_INSTANCE_PRIVATE_KEY }}
           source: "./deploy/*" # github action 서버 내부 경로

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - SPRING_PROFILE_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev
     env_file:
       - spring.env


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #15**

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
CD로 배포 되는 중에 오타로 인해 환경변수가 제대로 들어가지 않아 실행되지 않는 현상 발생하여 조치 했습니다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [ ] docker-compose.yml 파일에 spring.active.profiles 환경변수 명 변경
- [ ] cd-dev-with-docker-compose.yml에서 EC2 SSH 접속 포트 변경 

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- docker-compose.yml 파일에서 docker 환경에 환경변수를 미리 넣어둘 수 있는데 spring.profiles.active를 spring.profile.active로 적어 수정하였습니다.
- 추가로 SSH 접속시 포트 환경 변수 명도 오타가 나있어서 수정처리했습니다!

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
