### PR TITLE
[#21] CI 작업 기록 삭제 조치

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   # 작업 명(본인이 지으면 됨)
   build:
-    environment: develop # 환경 develop
     runs-on: ubuntu-latest # 대여해주는 서버
     steps:
       - uses: actions/checkout@v3 # 코드 저장소에 올려둔 코드 CI 서버 내려받은 후 특정 브랜치 전환하는 행위


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #21** 

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- Repository의 Deployment에 쌓이는 CI 로직을 삭제하기 위한 작업

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] ci.yml 파일에서 develop 환경 삭제

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- CI workflow가 [배포 기록](https://github.com/prgrms-be-devcourse/BE-04-TICKETPARIS/deployments)에도 쌓여 실제 배포되는 기록만 남기기 위해 작업을 진행했습니다!
- [관련 글](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)을 보시면 github에서 환경을 사용한다는 것은 글의 제목처럼 `배포`를 위한 환경 사용으로 정해지는 것 같습니다. 따라서 ci작업시 develop 환경을 사용하게 되면 자동으로 `배포`환경이 사용되어진다고 여겨져 ci작업이 같이 기록되고 있었던 것 같네요!

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
