### PR TITLE
[#37] 예매시 스케줄 좌석 수 변경 관련 기능

### DIFF
--- a/src/main/java/com/programmers/ticketparis/domain/reservation/Reservation.java
+++ b/src/main/java/com/programmers/ticketparis/domain/reservation/Reservation.java
@@ -41,7 +41,7 @@ public class Reservation {
 
     private void validateReservationStatus(ReservationStatus reservationStatus) {
         if (reservationStatus != ReservationStatus.COMPLETED) {
-            throw new ReservationException(NOT_EXIST_RESERVATION_STATUS, List.of(reservationStatus.toString()));
+            throw new ReservationException(RESERVATION_STATUS_INVALID, List.of(reservationStatus.toString()));
         }
     }
 }

--- a/src/main/java/com/programmers/ticketparis/domain/schedule/Schedule.java
+++ b/src/main/java/com/programmers/ticketparis/domain/schedule/Schedule.java
@@ -1,6 +1,10 @@
 package com.programmers.ticketparis.domain.schedule;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.programmers.ticketparis.exception.ExceptionRule;
+import com.programmers.ticketparis.exception.ScheduleException;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/com/programmers/ticketparis/domain/schedule/Schedule.java
+++ b/src/main/java/com/programmers/ticketparis/domain/schedule/Schedule.java
@@ -1,9 +1,10 @@
 package com.programmers.ticketparis.domain.schedule;
 
+import static com.programmers.ticketparis.exception.ExceptionRule.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.programmers.ticketparis.exception.ExceptionRule;
 import com.programmers.ticketparis.exception.ScheduleException;
 
 import jakarta.validation.constraints.NotNull;
@@ -39,5 +40,19 @@ public class Schedule {
         this.sequence = sequence;
         this.seatsCount = seatsCount;
         this.performanceId = performanceId;
+    }
+
+    public void decreaseSeatsCount() {
+        if (seatsCount == 0) {
+            throw new ScheduleException(SCHEDULE_NO_SEATS, List.of(String.valueOf(seatsCount)));
+        }
+        seatsCount -= 1;
+    }
+
+    public void increaseSeatsCount(Integer totalSeatsCount) {
+        if (seatsCount == totalSeatsCount) {
+            throw new ScheduleException(SCHEDULE_FULL_SEATS, List.of(String.valueOf(seatsCount)));
+        }
+        seatsCount += 1;
     }
 }

--- a/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
@@ -9,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionRule {
 
-    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 ID와 스케줄 ID에 해당하는 스케줄이 존재하지 않아 삭제 불가"),
+    RESERVATION_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 예매를 찾을 수 없음"),
+    RESERVATION_STATUS_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "올바르지 않은 예매 상태"),
+
+    SCHEDULE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 스케줄을 찾을 수 없음"),
 
     NOT_EXIST_RESERVATION(HttpStatus.NOT_FOUND, "요청한 예매 ID가 존재하지 않음"),
     NOT_EXIST_RESERVATION_STATUS(HttpStatus.NOT_FOUND, "존재하지 않는 예약 상태"),

--- a/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
@@ -13,6 +13,8 @@ public enum ExceptionRule {
     RESERVATION_STATUS_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "올바르지 않은 예매 상태"),
 
     SCHEDULE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 스케줄을 찾을 수 없음"),
+    SCHEDULE_NO_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수가 없음"),
+    SCHEDULE_FULL_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수는 전체 좌석 수보다 많을 수 없음"),
 
     NOT_EXIST_RESERVATION(HttpStatus.NOT_FOUND, "요청한 예매 ID가 존재하지 않음"),
     NOT_EXIST_RESERVATION_STATUS(HttpStatus.NOT_FOUND, "존재하지 않는 예약 상태"),

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
@@ -40,4 +40,9 @@ public class MybatisScheduleRepository implements ScheduleRepository {
     public Integer deleteById(Long scheduleId) {
         return scheduleMapper.deleteById(scheduleId);
     }
+
+    @Override
+    public void updateSeatsCountById(Long scheduleId, Integer seatsCount) {
+        scheduleMapper.updateSeatsCountById(scheduleId, seatsCount);
+    }
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -18,4 +18,6 @@ public interface ScheduleMapper {
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);
+
+    void updateSeatsCountById(Long scheduleId, Integer seatsCount);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -14,7 +14,7 @@ public interface ScheduleMapper {
     Integer findHallSeatsCountByPerformanceId(Long performanceId);
 
     Optional<Schedule> findById(Long scheduleId);
-    
+
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -14,7 +14,7 @@ public interface ScheduleMapper {
     Integer findHallSeatsCountByPerformanceId(Long performanceId);
 
     Optional<Schedule> findById(Long scheduleId);
-
+    
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -15,4 +15,6 @@ public interface ScheduleRepository {
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);
+
+    void updateSeatsCountById(Long scheduleId, Integer seatsCount);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -11,7 +11,7 @@ public interface ScheduleRepository {
     Integer findHallSeatsCountByPerformanceId(Long performanceId);
 
     Optional<Schedule> findById(Long scheduleId);
-
+    
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -11,7 +11,7 @@ public interface ScheduleRepository {
     Integer findHallSeatsCountByPerformanceId(Long performanceId);
 
     Optional<Schedule> findById(Long scheduleId);
-    
+
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -11,7 +11,6 @@ import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
-import com.programmers.ticketparis.exception.ExceptionRule;
 import com.programmers.ticketparis.exception.ReservationException;
 import com.programmers.ticketparis.repository.reservation.ReservationRepository;
 import com.programmers.ticketparis.service.schedule.ScheduleService;
@@ -43,7 +42,7 @@ public class ReservationService {
     public ReservationResponse findReservationById(Long reservationId) {
         return reservationRepository.findById(reservationId)
             .map(ReservationResponse::from)
-            .orElseThrow(() -> new ReservationException(ExceptionRule.NOT_EXIST_RESERVATION,
+            .orElseThrow(() -> new ReservationException(NOT_EXIST_RESERVATION,
                 List.of(String.valueOf(reservationId))));
     }
 
@@ -61,7 +60,7 @@ public class ReservationService {
 
     private void validateReservationExists(Long reservationId) {
         if (!reservationRepository.existsById(reservationId)) {
-            throw new ReservationException(ExceptionRule.NOT_EXIST_RESERVATION, List.of(String.valueOf(reservationId)));
+            throw new ReservationException(NOT_EXIST_RESERVATION, List.of(String.valueOf(reservationId)));
         }
     }
 }

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
+import com.programmers.ticketparis.domain.schedule.Schedule;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.exception.ReservationException;
@@ -28,6 +29,9 @@ public class ReservationService {
     @Transactional
     public Long createReservation(ReservationCreateRequest reservationCreateRequest) {
         Reservation reservation = reservationCreateRequest.toEntity();
+        Schedule schedule = scheduleService.findByScheduleId(reservation.getScheduleId());
+        schedule.decreaseSeatsCount();
+        scheduleService.updateSeatsCountById(schedule.getScheduleId(), schedule.getSeatsCount());
 
         return reservationRepository.save(reservation);
     }
@@ -35,6 +39,9 @@ public class ReservationService {
     @Transactional
     public Long cancelReservationById(Long reservationId) {
         validateReservationExists(reservationId);
+        Reservation reservation = getReservationById(reservationId);
+        Schedule schedule = scheduleService.findByScheduleId(reservation.getScheduleId());
+        scheduleService.updateSeatsCountById(schedule.getScheduleId(), schedule.getSeatsCount());
 
         return reservationRepository.updateReservationStatusById(reservationId, ReservationStatus.CANCELED);
     }

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -1,5 +1,7 @@
 package com.programmers.ticketparis.service.reservation;
 
+import static com.programmers.ticketparis.exception.ExceptionRule.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +14,7 @@ import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.exception.ExceptionRule;
 import com.programmers.ticketparis.exception.ReservationException;
 import com.programmers.ticketparis.repository.reservation.ReservationRepository;
+import com.programmers.ticketparis.service.schedule.ScheduleService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final ScheduleService scheduleService;
 
     @Transactional
     public Long createReservation(ReservationCreateRequest reservationCreateRequest) {
@@ -45,7 +49,7 @@ public class ReservationService {
 
     private Reservation getReservationById(Long reservationId) {
         return reservationRepository.findById(reservationId)
-            .orElseThrow(() -> new ReservationException(ExceptionRule.RESERVATION_NOT_EXIST,
+            .orElseThrow(() -> new ReservationException(RESERVATION_NOT_EXIST,
                 List.of(String.valueOf(reservationId))));
     }
 

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -30,6 +30,7 @@ public class ReservationService {
     public Long createReservation(ReservationCreateRequest reservationCreateRequest) {
         Reservation reservation = reservationCreateRequest.toEntity();
         Schedule schedule = scheduleService.findByScheduleId(reservation.getScheduleId());
+
         schedule.decreaseSeatsCount();
         scheduleService.updateSeatsCountById(schedule.getScheduleId(), schedule.getSeatsCount());
 
@@ -39,9 +40,11 @@ public class ReservationService {
     @Transactional
     public Long cancelReservationById(Long reservationId) {
         validateReservationExists(reservationId);
+
         Reservation reservation = getReservationById(reservationId);
         Schedule schedule = scheduleService.findByScheduleId(reservation.getScheduleId());
         Integer totalSeatsCount = scheduleService.findHallSeatsCountByPerformanceId(schedule.getPerformanceId());
+
         schedule.increaseSeatsCount(totalSeatsCount);
         scheduleService.updateSeatsCountById(schedule.getScheduleId(), schedule.getSeatsCount());
 

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -43,6 +43,12 @@ public class ReservationService {
                 List.of(String.valueOf(reservationId))));
     }
 
+    private Reservation getReservationById(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ReservationException(ExceptionRule.RESERVATION_NOT_EXIST,
+                List.of(String.valueOf(reservationId))));
+    }
+
     public List<ReservationResponse> findAllReservations() {
         List<Reservation> reservations = reservationRepository.findAll();
 

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -41,6 +41,8 @@ public class ReservationService {
         validateReservationExists(reservationId);
         Reservation reservation = getReservationById(reservationId);
         Schedule schedule = scheduleService.findByScheduleId(reservation.getScheduleId());
+        Integer totalSeatsCount = scheduleService.findHallSeatsCountByPerformanceId(schedule.getPerformanceId());
+        schedule.increaseSeatsCount(totalSeatsCount);
         scheduleService.updateSeatsCountById(schedule.getScheduleId(), schedule.getSeatsCount());
 
         return reservationRepository.updateReservationStatusById(reservationId, ReservationStatus.CANCELED);

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -39,7 +39,7 @@ public class ScheduleService {
     public void deleteScheduleById(Long scheduleId) {
         if (!scheduleRepository.existsById(scheduleId)) {
             List<String> rejectedValues = List.of(String.valueOf(scheduleId));
-            throw new ScheduleException(SCHEDULE_NOT_FOUND, rejectedValues);
+            throw new ScheduleException(SCHEDULE_NOT_EXIST, rejectedValues);
         }
 
         scheduleRepository.deleteById(scheduleId);

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -35,6 +35,11 @@ public class ScheduleService {
         return ScheduleResponse.from(savedScheduleId);
     }
 
+    public Schedule findByScheduleId(Long scheduleId) {
+        return scheduleRepository.findByScheduleId(scheduleId)
+            .orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_EXIST, List.of(String.valueOf(scheduleId))));
+    }
+
     @Transactional
     public void deleteScheduleById(Long scheduleId) {
         if (!scheduleRepository.existsById(scheduleId)) {
@@ -43,5 +48,10 @@ public class ScheduleService {
         }
 
         scheduleRepository.deleteById(scheduleId);
+    }
+
+    @Transactional
+    public void updateSeatsCountById(Long scheduleId, Integer seatsCount) {
+        scheduleRepository.updateSeatsCountById(scheduleId, seatsCount);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -27,7 +27,7 @@ public class ScheduleService {
         // TODO: performanceId에 해당하는 공연 데이터가 없는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
         // TODO: startDatetime이 공연의 시작, 종료날짜 범위를 벗어나는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
 
-        Integer seatsCount = scheduleRepository.findHallSeatsCountByPerformanceId(
+        Integer seatsCount = findHallSeatsCountByPerformanceId(
             scheduleCreateRequest.getPerformanceId());
         Schedule schedule = scheduleCreateRequest.toEntity(seatsCount);
         Long savedScheduleId = scheduleRepository.save(schedule);
@@ -53,5 +53,9 @@ public class ScheduleService {
     @Transactional
     public void updateSeatsCountById(Long scheduleId, Integer seatsCount) {
         scheduleRepository.updateSeatsCountById(scheduleId, seatsCount);
+    }
+
+    public Integer findHallSeatsCountByPerformanceId(Long performanceId) {
+        return scheduleRepository.findHallSeatsCountByPerformanceId(performanceId);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -36,7 +36,7 @@ public class ScheduleService {
     }
 
     public Schedule findByScheduleId(Long scheduleId) {
-        return scheduleRepository.findByScheduleId(scheduleId)
+        return scheduleRepository.findById(scheduleId)
             .orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_EXIST, List.of(String.valueOf(scheduleId))));
     }
 

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -16,19 +16,19 @@
         WHERE p.performance_id = #{performanceId};
     </select>
 
-    <select id="findById" resultType="Schedule">
+    <select id="findByPerformanceIdAndScheduleId" resultType="Schedule">
         SELECT schedule_id, start_datetime, sequence, seats_count, performance_id, created_datetime, updated_datetime
         FROM schedule
         WHERE schedule_id = #{scheduleId};
     </select>
 
-    <select id="existsById" resultType="Boolean">
+    <select id="existsByPerformanceIdAndScheduleId" resultType="Boolean">
         SELECT EXISTS(SELECT schedule_id
                       FROM schedule
                       WHERE schedule_id = #{scheduleId});
     </select>
 
-    <delete id="deleteById">
+    <delete id="deleteByPerformanceIdAndScheduleId">
         DELETE
         FROM schedule
         WHERE schedule_id = #{scheduleId};

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -16,25 +16,19 @@
         WHERE p.performance_id = #{performanceId};
     </select>
 
-    <select id="findByPerformanceIdAndScheduleId" resultType="Schedule">
+    <select id="findById" resultType="Schedule">
         SELECT schedule_id, start_datetime, sequence, seats_count, performance_id, created_datetime, updated_datetime
         FROM schedule
         WHERE schedule_id = #{scheduleId};
     </select>
 
-    <select id="findByScheduleId" resultType="Schedule">
-        SELECT schedule_id, start_datetime, sequence, seats_count, performance_id, created_datetime, updated_datetime
-        FROM schedule
-        WHERE schedule_id = #{scheduleId};
-    </select>
-
-    <select id="existsByPerformanceIdAndScheduleId" resultType="Boolean">
+    <select id="existsById" resultType="Boolean">
         SELECT EXISTS(SELECT schedule_id
                       FROM schedule
                       WHERE schedule_id = #{scheduleId});
     </select>
 
-    <delete id="deleteByPerformanceIdAndScheduleId">
+    <delete id="deleteById">
         DELETE
         FROM schedule
         WHERE schedule_id = #{scheduleId};

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -22,6 +22,12 @@
         WHERE schedule_id = #{scheduleId};
     </select>
 
+    <select id="findByScheduleId" resultType="Schedule">
+        SELECT schedule_id, start_datetime, sequence, seats_count, performance_id, created_datetime, updated_datetime
+        FROM schedule
+        WHERE schedule_id = #{scheduleId};
+    </select>
+
     <select id="existsByPerformanceIdAndScheduleId" resultType="Boolean">
         SELECT EXISTS(SELECT schedule_id
                       FROM schedule

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -40,4 +40,10 @@
         WHERE schedule_id = #{scheduleId};
     </delete>
 
+    <update id="updateSeatsCountById">
+        UPDATE schedule
+        SET seats_count = #{seatsCount}
+        WHERE schedule_id = #{scheduleId}
+    </update>
+
 </mapper>

--- a/src/test/java/com/programmers/ticketparis/domain/reservation/ReservationTest.java
+++ b/src/test/java/com/programmers/ticketparis/domain/reservation/ReservationTest.java
@@ -39,6 +39,6 @@ class ReservationTest {
             .reservationStatus(ReservationStatus.CANCELED)
             .scheduleId(1L)
             .customerId(1L)
-            .build()).isInstanceOf(ReservationException.class).hasMessage("존재하지 않는 예약 상태");
+            .build()).isInstanceOf(ReservationException.class).hasMessage("올바르지 않은 예매 상태");
     }
 }

--- a/src/test/java/com/programmers/ticketparis/service/schedule/ScheduleServiceTest.java
+++ b/src/test/java/com/programmers/ticketparis/service/schedule/ScheduleServiceTest.java
@@ -26,6 +26,6 @@ class ScheduleServiceTest {
         //when, then
         assertThatThrownBy(() -> scheduleService.deleteScheduleById(scheduleId))
             .isInstanceOf(ScheduleException.class)
-            .hasMessage(SCHEDULE_NOT_FOUND.getMessage());
+            .hasMessage(SCHEDULE_NOT_EXIST.getMessage());
     }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #37**

**영주 & 창현 페어프로그래밍으로 진행**

### 📑 PR 개요
- 공연 예매시 스케줄의 좌석을 -1 하는 기능을 개발
- 예매한 공연을 취소할 때 스케줄의 좌석을 +1 하는 기능을 개발

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
**공연 예매**
- [X] 해당하는 공연의 스케줄 좌석 수 감소
- [X] 해당하는 공연의 스케줄 좌석이 부족한 경우 예외

**예매 취소**
- [X] 해당하는 공연의 스케줄 좌석 수 증가
- [X] 해당하는 공연의 스케줄 좌석이 공연장 좌석보다 많은 경우 예외

**컨벤션** 
- [X] 네이버 컨벤션 오류 재설정
- [X] 네이밍 변경

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 페어프로그래밍을 하며 컨벤션이 맞지 않은 부분들이 좀 있어서 수정하면서 작업했고, 네이버 컨벤션 설정이 먹지 않아 재설정하다보니 Files changed에 기능과 관련 없는 컨벤션 적용 파일들이 있을 수 있으니 양해부탁드립니다 🙏 🙏

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
