### PR TITLE
[#40] Redis 서버 환경 구축

### DIFF
--- a/.github/workflows/cd-dev-with-docker-compose.yml
+++ b/.github/workflows/cd-dev-with-docker-compose.yml
@@ -10,6 +10,11 @@ jobs:
   deploy-ec2:
     environment: develop # 환경 develop
     runs-on: ubuntu-latest # 대여해주는 서버
+    env:
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+
     steps:
       - uses: actions/checkout@v3 # 코드 저장소에 올려둔 코드 CI 서버 내려받은 후 특정 브랜치 전환하는 행위
       - name: Set up JDK 17

--- a/.github/workflows/cd-dev-with-docker-compose.yml
+++ b/.github/workflows/cd-dev-with-docker-compose.yml
@@ -56,6 +56,9 @@ jobs:
           echo 'DATABASE_DEV_MYSQL_PASSWORD=${{ secrets.DATABASE_DEV_MYSQL_PASSWORD }}' >> spring.env
           echo 'DATABASE_DEV_MYSQL_URL=${{ secrets.DATABASE_DEV_MYSQL_URL }}' >> spring.env
           echo 'DATABASE_DEV_MYSQL_USERNAME=${{ secrets.DATABASE_DEV_MYSQL_USERNAME }}' >> spring.env
+          echo 'REDIS_HOST=${{ secrets.REDIS_HOST }}' >> spring.env
+          echo 'REDIS_PORT=${{ secrets.REDIS_PORT }}' >> spring.env
+          echo 'REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}' >> spring.env
 
       # docker-compose 파일과 env파일 EC2 서버로 전달하기
       - name: send file to EC2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
   # 작업 명(본인이 지으면 됨)
   build:
     runs-on: ubuntu-latest # 대여해주는 서버
+    env:
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+
     steps:
       - uses: actions/checkout@v3 # 코드 저장소에 올려둔 코드 CI 서버 내려받은 후 특정 브랜치 전환하는 행위
       - name: Set up JDK 17

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.3'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/programmers/ticketparis/redis/RedisConfig.java
+++ b/src/main/java/com/programmers/ticketparis/redis/RedisConfig.java
@@ -7,11 +7,9 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/programmers/ticketparis/redis/RedisConfig.java
+++ b/src/main/java/com/programmers/ticketparis/redis/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.programmers.ticketparis.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
     resources:
       add-mappings: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
 # MyBatis 설정
 mybatis:
   # 마이바티스에서 타입 정보를 사용할 때 패키지 이름을 적어줘야하는데, 여기에 명시하면 패키지 이름 생략 가능

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,12 @@ spring:
     url: jdbc:h2:mem:ticketparis
     username: sa
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
 mybatis:
   type-aliases-package: com.programmers.ticketparis.domain
   configuration:


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #40**

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- Redis에 로그인 세션 저장
- Redis에 랭킹 데이터를 저장
- 위 두가지 작업을 하기 위해 Redis 서버를 local과 dev환경 나눠서 구축

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] local 환경에서의 Docker Redis 구축
- [x] dev 환경에서의 Redis인 AWS Elastic Cache 구축
- [x] 환경에 따른 Spring Boot와 연동

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- local환경은 제가 가지고 있는 개인 NAS 서버로 구축했습니다.
- dev환경은 AWS에서 AWS Elastic Cache로 구축했으며 외부에서 접근이 불가하고 EC2에서만 접근이 가능합니다.

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
