### PR TITLE
[#39] 공연, 예매, 스케줄 페이지네이션 기능 적용 

### DIFF
--- a/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
+++ b/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
@@ -17,13 +17,13 @@ public class Pageable {
 
     private Integer pageNum;
     private Integer size;
-    private Integer skipData;
+    private Integer offset;
 
     @Builder
     private Pageable(Integer pageNum, Integer size) {
         isNumberPositive(pageNum);
         isNumberPositive(size);
-        this.skipData = (pageNum - 1) * size;
+        this.offset = (pageNum - 1) * size;
         this.pageNum = pageNum;
         this.size = size;
     }

--- a/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
+++ b/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
@@ -19,14 +19,14 @@ public class Pageable {
 
     @Builder
     private Pageable(Integer pageNum, Integer size) {
-        isNumberPositive(pageNum);
-        isNumberPositive(size);
+        validateNumberIsPositive(pageNum);
+        validateNumberIsPositive(size);
         this.offset = (pageNum - 1) * size;
         this.pageNum = pageNum;
         this.size = size;
     }
 
-    private void isNumberPositive(Integer number) {
+    private void validateNumberIsPositive(Integer number) {
         if (number <= 0) {
             throw new CommonException(COMMON_NUMBER_IS_NOT_POSITIVE, number);
         }

--- a/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
+++ b/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
@@ -1,4 +1,4 @@
-package com.programmers.ticketparis.domain.pageable;
+package com.programmers.ticketparis.common.pageable;
 
 import static com.programmers.ticketparis.exception.ExceptionRule.*;
 

--- a/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
+++ b/src/main/java/com/programmers/ticketparis/common/pageable/Pageable.java
@@ -2,8 +2,6 @@ package com.programmers.ticketparis.common.pageable;
 
 import static com.programmers.ticketparis.exception.ExceptionRule.*;
 
-import java.util.List;
-
 import com.programmers.ticketparis.exception.CommonException;
 
 import lombok.AccessLevel;
@@ -30,7 +28,7 @@ public class Pageable {
 
     private void isNumberPositive(Integer number) {
         if (number <= 0) {
-            throw new CommonException(NUMBER_IS_NOT_POSITIVE, List.of(String.valueOf(number)));
+            throw new CommonException(COMMON_NUMBER_IS_NOT_POSITIVE, number);
         }
     }
 }

--- a/src/main/java/com/programmers/ticketparis/controller/performance/PerformanceController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/performance/PerformanceController.java
@@ -10,13 +10,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
 import com.programmers.ticketparis.dto.performance.response.PerformanceIdResponse;
 import com.programmers.ticketparis.dto.performance.response.PerformanceResponse;
+import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.service.performance.PerformanceService;
 
 import jakarta.validation.Valid;
@@ -42,8 +45,29 @@ public class PerformanceController {
     }
 
     @GetMapping
-    public List<PerformanceResponse> findAllPerformances() {
-        return performanceService.findAllPerformances();
+    public List<PerformanceResponse> findPerformancesByPage(
+        @RequestParam Integer pageNum,
+        @RequestParam Integer size) {
+        Pageable pageable = Pageable.builder()
+            .pageNum(pageNum)
+            .size(size)
+            .build();
+
+        return performanceService.findPerformancesByPage(pageable);
+    }
+
+    @GetMapping("/{performanceId}/reservations")
+    public List<ReservationResponse> findReservationsByPerformanceIdWithPage(
+        @PathVariable Long performanceId,
+        @RequestParam Integer pageNum,
+        @RequestParam Integer size) {
+        Pageable pageable = Pageable.builder()
+            .pageNum(pageNum)
+            .size(size)
+            .build();
+
+        return performanceService.findReservationsByPerformanceIdWithPage(
+            performanceId, pageable);
     }
 
     @PatchMapping("/{performanceId}")

--- a/src/main/java/com/programmers/ticketparis/controller/performance/PerformanceController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/performance/PerformanceController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
 import com.programmers.ticketparis.dto.performance.response.PerformanceIdResponse;

--- a/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
@@ -9,9 +9,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;
 import com.programmers.ticketparis.dto.reservation.response.ReservationIdResponse;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
@@ -45,7 +47,17 @@ public class ReservationController {
     }
 
     @GetMapping
-    public List<ReservationResponse> findAllReservations() {
-        return reservationService.findAllReservations();
+    public List<ReservationResponse> findReservationsByPage(
+        @RequestParam Integer pageNum,
+        @RequestParam Integer size
+    ) {
+        Pageable pageable = Pageable.builder()
+            .pageNum(pageNum)
+            .size(size)
+            .build();
+        
+        List<ReservationResponse> reservationResponses = reservationService.findReservationsByPage(pageable);
+
+        return reservationResponses;
     }
 }

--- a/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;
 import com.programmers.ticketparis.dto.reservation.response.ReservationIdResponse;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;

--- a/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/reservation/ReservationController.java
@@ -55,9 +55,7 @@ public class ReservationController {
             .pageNum(pageNum)
             .size(size)
             .build();
-        
-        List<ReservationResponse> reservationResponses = reservationService.findReservationsByPage(pageable);
 
-        return reservationResponses;
+        return reservationService.findReservationsByPage(pageable);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
+import com.programmers.ticketparis.dto.schedule.response.ScheduleIdResponse;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
 import com.programmers.ticketparis.service.schedule.ScheduleService;
 
@@ -30,7 +31,7 @@ public class ScheduleController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ScheduleResponse createSchedule(@Valid @RequestBody ScheduleCreateRequest request) {
+    public ScheduleIdResponse createSchedule(@Valid @RequestBody ScheduleCreateRequest request) {
         return scheduleService.createSchedule(request);
     }
 

--- a/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleIdResponse;

--- a/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleIdResponse;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
@@ -51,8 +52,21 @@ public class ScheduleController {
             .size(size)
             .build();
 
-        List<ScheduleResponse> scheduleResponses = scheduleService.findSchedulesByPage(pageable);
+        return scheduleService.findSchedulesByPage(pageable);
+    }
 
-        return scheduleResponses;
+    @GetMapping("/{scheduleId}/reservations")
+    public List<ReservationResponse> findReservationsByScheduleIdWithPage(
+        @RequestParam Integer pageNum,
+        @RequestParam Integer size,
+        @PathVariable Integer scheduleId
+    ) {
+        Pageable pageable = Pageable.builder()
+            .pageNum(pageNum)
+            .size(size)
+            .build();
+
+        return scheduleService.findReservationsByScheduleIdWithPage(
+            scheduleId, pageable);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/schedule/ScheduleController.java
@@ -1,14 +1,19 @@
 package com.programmers.ticketparis.controller.schedule;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
 import com.programmers.ticketparis.service.schedule.ScheduleService;
@@ -33,5 +38,20 @@ public class ScheduleController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteScheduleById(@PathVariable Long scheduleId) {
         scheduleService.deleteScheduleById(scheduleId);
+    }
+
+    @GetMapping
+    public List<ScheduleResponse> findSchedulesByPage(
+        @RequestParam Integer pageNum,
+        @RequestParam Integer size
+    ) {
+        Pageable pageable = Pageable.builder()
+            .pageNum(pageNum)
+            .size(size)
+            .build();
+
+        List<ScheduleResponse> scheduleResponses = scheduleService.findSchedulesByPage(pageable);
+
+        return scheduleResponses;
     }
 }

--- a/src/main/java/com/programmers/ticketparis/domain/pageable/Pageable.java
+++ b/src/main/java/com/programmers/ticketparis/domain/pageable/Pageable.java
@@ -1,0 +1,36 @@
+package com.programmers.ticketparis.domain.pageable;
+
+import static com.programmers.ticketparis.exception.ExceptionRule.*;
+
+import java.util.List;
+
+import com.programmers.ticketparis.exception.CommonException;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pageable {
+
+    private Integer pageNum;
+    private Integer size;
+    private Integer skipData;
+
+    @Builder
+    private Pageable(Integer pageNum, Integer size) {
+        isNumberPositive(pageNum);
+        isNumberPositive(size);
+        this.skipData = (pageNum - 1) * size;
+        this.pageNum = pageNum;
+        this.size = size;
+    }
+
+    private void isNumberPositive(Integer number) {
+        if (number <= 0) {
+            throw new CommonException(NUMBER_IS_NOT_POSITIVE, List.of(String.valueOf(number)));
+        }
+    }
+}

--- a/src/main/java/com/programmers/ticketparis/dto/schedule/response/ScheduleIdResponse.java
+++ b/src/main/java/com/programmers/ticketparis/dto/schedule/response/ScheduleIdResponse.java
@@ -1,0 +1,14 @@
+package com.programmers.ticketparis.dto.schedule.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "from")
+public class ScheduleIdResponse {
+
+    private Long scheduleId;
+}

--- a/src/main/java/com/programmers/ticketparis/dto/schedule/response/ScheduleResponse.java
+++ b/src/main/java/com/programmers/ticketparis/dto/schedule/response/ScheduleResponse.java
@@ -1,14 +1,41 @@
 package com.programmers.ticketparis.dto.schedule.response;
 
+import java.time.LocalDateTime;
+
+import com.programmers.ticketparis.domain.schedule.Schedule;
+
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(staticName = "from")
 public class ScheduleResponse {
 
     private Long scheduleId;
+    private LocalDateTime startDatetime;
+    private Integer sequence;
+    private Integer seatsCount;
+    private Long performanceId;
+
+    @Builder
+    private ScheduleResponse(Long scheduleId, LocalDateTime startDatetime, Integer sequence, Integer seatsCount,
+        Long performanceId) {
+        this.scheduleId = scheduleId;
+        this.startDatetime = startDatetime;
+        this.sequence = sequence;
+        this.seatsCount = seatsCount;
+        this.performanceId = performanceId;
+    }
+
+    public static ScheduleResponse from(Schedule schedule) {
+        return ScheduleResponse.builder()
+            .scheduleId(schedule.getScheduleId())
+            .startDatetime(schedule.getStartDatetime())
+            .sequence(schedule.getSequence())
+            .seatsCount(schedule.getSeatsCount())
+            .performanceId(schedule.getPerformanceId())
+            .build();
+    }
 }

--- a/src/main/java/com/programmers/ticketparis/exception/CommonException.java
+++ b/src/main/java/com/programmers/ticketparis/exception/CommonException.java
@@ -1,0 +1,10 @@
+package com.programmers.ticketparis.exception;
+
+import java.util.List;
+
+public class CommonException extends BusinessException {
+
+    public CommonException(ExceptionRule rule, List<String> rejectedValues) {
+        super(rule, rejectedValues);
+    }
+}

--- a/src/main/java/com/programmers/ticketparis/exception/CommonException.java
+++ b/src/main/java/com/programmers/ticketparis/exception/CommonException.java
@@ -1,10 +1,8 @@
 package com.programmers.ticketparis.exception;
 
-import java.util.List;
-
 public class CommonException extends BusinessException {
 
-    public CommonException(ExceptionRule rule, List<String> rejectedValues) {
+    public CommonException(ExceptionRule rule, Object... rejectedValues) {
         super(rule, rejectedValues);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
@@ -15,7 +15,7 @@ public enum ExceptionRule {
     SCHEDULE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 스케줄을 찾을 수 없음"),
     SCHEDULE_NO_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수가 없음"),
     SCHEDULE_FULL_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수는 전체 좌석 수보다 많을 수 없음"),
-
+    
     CUSTOMER_NOT_EXIST(HttpStatus.NOT_FOUND, "요청한 구매자 ID가 존재하지 않음"),
     CUSTOMER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 가입된 username 또는 email로 요청"),
 
@@ -24,6 +24,8 @@ public enum ExceptionRule {
 
     PERFORMANCE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당 공연이 존재하지 않음"),
     PERFORMANCE_START_DATE_AFTER_END_DATE(HttpStatus.BAD_REQUEST, "공연 시작 날짜는 공연 종료 날짜 이후가 될 수 없음"),
+
+    NUMBER_IS_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "입력한 값이 양수가 아님"),
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "사용자 입력 유효성 검사 실패"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URL에 해당하는 리소스를 찾을 수 없음"),

--- a/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/exception/ExceptionRule.java
@@ -15,7 +15,7 @@ public enum ExceptionRule {
     SCHEDULE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 스케줄을 찾을 수 없음"),
     SCHEDULE_NO_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수가 없음"),
     SCHEDULE_FULL_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수는 전체 좌석 수보다 많을 수 없음"),
-    
+
     CUSTOMER_NOT_EXIST(HttpStatus.NOT_FOUND, "요청한 구매자 ID가 존재하지 않음"),
     CUSTOMER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 가입된 username 또는 email로 요청"),
 
@@ -25,7 +25,7 @@ public enum ExceptionRule {
     PERFORMANCE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당 공연이 존재하지 않음"),
     PERFORMANCE_START_DATE_AFTER_END_DATE(HttpStatus.BAD_REQUEST, "공연 시작 날짜는 공연 종료 날짜 이후가 될 수 없음"),
 
-    NUMBER_IS_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "입력한 값이 양수가 아님"),
+    COMMON_NUMBER_IS_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "입력한 값이 양수가 아님"),
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "사용자 입력 유효성 검사 실패"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 URL에 해당하는 리소스를 찾을 수 없음"),

--- a/src/main/java/com/programmers/ticketparis/repository/member/CustomerMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/member/CustomerMapper.java
@@ -1,4 +1,4 @@
-package com.programmers.ticketparis.mapper.member;
+package com.programmers.ticketparis.repository.member;
 
 import java.util.Optional;
 

--- a/src/main/java/com/programmers/ticketparis/repository/member/MyBatisCustomerRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/member/MyBatisCustomerRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.programmers.ticketparis.domain.member.Customer;
-import com.programmers.ticketparis.mapper.member.CustomerMapper;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/programmers/ticketparis/repository/member/MyBatisSellerRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/member/MyBatisSellerRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.programmers.ticketparis.domain.member.Seller;
-import com.programmers.ticketparis.mapper.member.SellerMapper;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/programmers/ticketparis/repository/member/SellerMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/member/SellerMapper.java
@@ -1,4 +1,4 @@
-package com.programmers.ticketparis.mapper.member;
+package com.programmers.ticketparis.repository.member;
 
 import java.util.Optional;
 

--- a/src/main/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/main/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepository.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
-import com.programmers.ticketparis.mapper.PerformanceMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,8 +38,13 @@ public class MybatisPerformanceRepository implements PerformanceRepository {
     }
 
     @Override
-    public List<Performance> findAll() {
-        return performanceMapper.findAll();
+    public List<Performance> findPerformancesByPage(Pageable pageable) {
+        return performanceMapper.findPerformancesByPage(pageable);
+    }
+
+    @Override
+    public List<Reservation> findReservationsByPerformanceIdWithPage(Long performanceId, Pageable pageable) {
+        return performanceMapper.findReservationsByPerformanceIdWithPage(performanceId, pageable);
     }
 
     @Override

--- a/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceMapper.java
@@ -1,11 +1,13 @@
-package com.programmers.ticketparis.mapper;
+package com.programmers.ticketparis.repository.performance;
 
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
 
 @Mapper
@@ -17,9 +19,12 @@ public interface PerformanceMapper {
 
     Optional<Performance> findById(Long performanceId);
 
-    List<Performance> findAll();
+    List<Performance> findPerformancesByPage(Pageable pageable);
+
+    List<Reservation> findReservationsByPerformanceIdWithPage(Long performanceId, Pageable pageable);
 
     void deleteById(Long performanceId);
 
     Boolean existsById(Long performanceId);
+
 }

--- a/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceMapper.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceRepository.java
@@ -3,7 +3,7 @@ package com.programmers.ticketparis.repository.performance;
 import java.util.List;
 import java.util.Optional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/performance/PerformanceRepository.java
@@ -3,7 +3,9 @@ package com.programmers.ticketparis.repository.performance;
 import java.util.List;
 import java.util.Optional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
 
 public interface PerformanceRepository {
@@ -14,7 +16,9 @@ public interface PerformanceRepository {
 
     Optional<Performance> findById(Long performanceId);
 
-    List<Performance> findAll();
+    List<Performance> findPerformancesByPage(Pageable pageable);
+
+    List<Reservation> findReservationsByPerformanceIdWithPage(Long performanceId, Pageable pageable);
 
     void deleteById(Long performanceId);
 

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 
@@ -32,8 +33,8 @@ public class MybatisReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public List<Reservation> findAll() {
-        return reservationMapper.findAll();
+    public List<Reservation> findReservationsByPage(Pageable pageable) {
+        return reservationMapper.findReservationsByPage(pageable);
     }
 
     @Override

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationMapper.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationMapper.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 
@@ -17,7 +18,7 @@ public interface ReservationMapper {
 
     Optional<Reservation> findById(Long reservationId);
 
-    List<Reservation> findAll();
+    List<Reservation> findReservationsByPage(Pageable pageable);
 
     Boolean existsById(Long reservationId);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationRepository.java
@@ -3,7 +3,7 @@ package com.programmers.ticketparis.repository.reservation;
 import java.util.List;
 import java.util.Optional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 

--- a/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/reservation/ReservationRepository.java
@@ -3,6 +3,7 @@ package com.programmers.ticketparis.repository.reservation;
 import java.util.List;
 import java.util.Optional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 
@@ -14,7 +15,7 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long reservationId);
 
-    List<Reservation> findAll();
+    List<Reservation> findReservationsByPage(Pageable pageable);
 
     Boolean existsById(Long reservationId);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
@@ -1,9 +1,11 @@
 package com.programmers.ticketparis.repository.schedule;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 import lombok.RequiredArgsConstructor;
@@ -44,5 +46,10 @@ public class MybatisScheduleRepository implements ScheduleRepository {
     @Override
     public void updateSeatsCountById(Long scheduleId, Integer seatsCount) {
         scheduleMapper.updateSeatsCountById(scheduleId, seatsCount);
+    }
+
+    @Override
+    public List<Schedule> findSchedulesByPage(Pageable pageable) {
+        return scheduleMapper.findSchedulesByPage(pageable);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/MybatisScheduleRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 import lombok.RequiredArgsConstructor;
@@ -51,5 +52,10 @@ public class MybatisScheduleRepository implements ScheduleRepository {
     @Override
     public List<Schedule> findSchedulesByPage(Pageable pageable) {
         return scheduleMapper.findSchedulesByPage(pageable);
+    }
+
+    @Override
+    public List<Reservation> findReservationsByScheduleIdWithPage(Integer scheduleId, Pageable pageable) {
+        return scheduleMapper.findReservationsByScheduleIdWithPage(scheduleId, pageable);
     }
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -1,9 +1,11 @@
 package com.programmers.ticketparis.repository.schedule;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 @Mapper
@@ -20,4 +22,6 @@ public interface ScheduleMapper {
     Integer deleteById(Long scheduleId);
 
     void updateSeatsCountById(Long scheduleId, Integer seatsCount);
+
+    List<Schedule> findSchedulesByPage(Pageable pageable);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleMapper.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 @Mapper
@@ -24,4 +25,6 @@ public interface ScheduleMapper {
     void updateSeatsCountById(Long scheduleId, Integer seatsCount);
 
     List<Schedule> findSchedulesByPage(Pageable pageable);
+
+    List<Reservation> findReservationsByScheduleIdWithPage(Integer scheduleId, Pageable pageable);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 public interface ScheduleRepository {
@@ -21,4 +22,6 @@ public interface ScheduleRepository {
     void updateSeatsCountById(Long scheduleId, Integer seatsCount);
 
     List<Schedule> findSchedulesByPage(Pageable pageable);
+
+    List<Reservation> findReservationsByScheduleIdWithPage(Integer scheduleId, Pageable pageable);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -1,7 +1,9 @@
 package com.programmers.ticketparis.repository.schedule;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
 public interface ScheduleRepository {
@@ -15,6 +17,8 @@ public interface ScheduleRepository {
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);
-
+    
     void updateSeatsCountById(Long scheduleId, Integer seatsCount);
+
+    List<Schedule> findSchedulesByPage(Pageable pageable);
 }

--- a/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/schedule/ScheduleRepository.java
@@ -3,7 +3,7 @@ package com.programmers.ticketparis.repository.schedule;
 import java.util.List;
 import java.util.Optional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 
@@ -18,7 +18,7 @@ public interface ScheduleRepository {
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);
-    
+
     void updateSeatsCountById(Long scheduleId, Integer seatsCount);
 
     List<Schedule> findSchedulesByPage(Pageable pageable);

--- a/src/main/java/com/programmers/ticketparis/service/performance/PerformanceService.java
+++ b/src/main/java/com/programmers/ticketparis/service/performance/PerformanceService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/main/java/com/programmers/ticketparis/service/performance/PerformanceService.java
+++ b/src/main/java/com/programmers/ticketparis/service/performance/PerformanceService.java
@@ -5,11 +5,13 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
 import com.programmers.ticketparis.dto.performance.response.PerformanceIdResponse;
 import com.programmers.ticketparis.dto.performance.response.PerformanceResponse;
+import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.exception.ExceptionRule;
 import com.programmers.ticketparis.exception.PerformanceException;
 import com.programmers.ticketparis.repository.performance.PerformanceRepository;
@@ -41,7 +43,6 @@ public class PerformanceService {
     }
 
     public PerformanceResponse findPerformanceById(Long performanceId) {
-
         return performanceRepository.findById(performanceId)
             .map(PerformanceResponse::fromEntity)
             .orElseThrow(
@@ -49,10 +50,15 @@ public class PerformanceService {
                     List.of(String.valueOf(performanceId))));
     }
 
-    public List<PerformanceResponse> findAllPerformances() {
+    public List<PerformanceResponse> findPerformancesByPage(Pageable pageable) {
+        return performanceRepository.findPerformancesByPage(pageable).stream()
+            .map(PerformanceResponse::fromEntity)
+            .toList();
+    }
 
-        return performanceRepository.findAll().stream()
-            .map(performance -> PerformanceResponse.fromEntity(performance))
+    public List<ReservationResponse> findReservationsByPerformanceIdWithPage(Long performanceId, Pageable pageable) {
+        return performanceRepository.findReservationsByPerformanceIdWithPage(performanceId, pageable).stream()
+            .map(ReservationResponse::from)
             .toList();
     }
 

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;

--- a/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
+++ b/src/main/java/com/programmers/ticketparis/service/reservation/ReservationService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.reservation.ReservationStatus;
 import com.programmers.ticketparis.dto.reservation.request.ReservationCreateRequest;
@@ -49,8 +50,8 @@ public class ReservationService {
             .orElseThrow(() -> new ReservationException(RESERVATION_NOT_EXIST, reservationId));
     }
 
-    public List<ReservationResponse> findAllReservations() {
-        List<Reservation> reservations = reservationRepository.findAll();
+    public List<ReservationResponse> findReservationsByPage(Pageable pageable) {
+        List<Reservation> reservations = reservationRepository.findReservationsByPage(pageable);
 
         return reservations.stream()
             .map(ReservationResponse::from).toList();

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
@@ -57,5 +58,11 @@ public class ScheduleService {
 
     public Integer findHallSeatsCountByPerformanceId(Long performanceId) {
         return scheduleRepository.findHallSeatsCountByPerformanceId(performanceId);
+    }
+
+    public List<ScheduleResponse> findSchedulesByPage(Pageable pageable) {
+        List<Schedule> schedules = scheduleRepository.findSchedulesByPage(pageable);
+
+        return schedules.stream().map(ScheduleResponse::from).toList();
     }
 }

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.domain.reservation.Reservation;
 import com.programmers.ticketparis.domain.schedule.Schedule;
+import com.programmers.ticketparis.dto.reservation.response.ReservationResponse;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleIdResponse;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
@@ -66,5 +68,11 @@ public class ScheduleService {
         List<Schedule> schedules = scheduleRepository.findSchedulesByPage(pageable);
 
         return schedules.stream().map(ScheduleResponse::from).toList();
+    }
+
+    public List<ReservationResponse> findReservationsByScheduleIdWithPage(Integer scheduleId, Pageable pageable) {
+        List<Reservation> reservations = scheduleRepository.findReservationsByScheduleIdWithPage(scheduleId, pageable);
+
+        return reservations.stream().map(ReservationResponse::from).toList();
     }
 }

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -28,7 +28,6 @@ public class ScheduleService {
 
     @Transactional
     public ScheduleIdResponse createSchedule(ScheduleCreateRequest scheduleCreateRequest) {
-
         // TODO: performanceId에 해당하는 공연 데이터가 없는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
         // TODO: startDatetime이 공연의 시작, 종료날짜 범위를 벗어나는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
 

--- a/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/service/schedule/ScheduleService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.schedule.Schedule;
 import com.programmers.ticketparis.dto.schedule.request.ScheduleCreateRequest;
+import com.programmers.ticketparis.dto.schedule.response.ScheduleIdResponse;
 import com.programmers.ticketparis.dto.schedule.response.ScheduleResponse;
 import com.programmers.ticketparis.exception.ScheduleException;
 import com.programmers.ticketparis.repository.schedule.ScheduleRepository;
@@ -24,7 +25,8 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public ScheduleResponse createSchedule(ScheduleCreateRequest scheduleCreateRequest) {
+    public ScheduleIdResponse createSchedule(ScheduleCreateRequest scheduleCreateRequest) {
+
         // TODO: performanceId에 해당하는 공연 데이터가 없는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
         // TODO: startDatetime이 공연의 시작, 종료날짜 범위를 벗어나는 경우 예외 처리 예정 (2023.09.06 김영주 작성)
 
@@ -33,7 +35,7 @@ public class ScheduleService {
         Schedule schedule = scheduleCreateRequest.toEntity(seatsCount);
         Long savedScheduleId = scheduleRepository.save(schedule);
 
-        return ScheduleResponse.from(savedScheduleId);
+        return ScheduleIdResponse.from(savedScheduleId);
     }
 
     public Schedule findByScheduleId(Long scheduleId) {

--- a/src/main/resources/mapper/CustomerMapper.xml
+++ b/src/main/resources/mapper/CustomerMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.programmers.ticketparis.mapper.member.CustomerMapper">
+<mapper namespace="com.programmers.ticketparis.repository.member.CustomerMapper">
 
     <insert id="save" useGeneratedKeys="true" keyProperty="customerId">
         INSERT INTO customer (username, password, name, email, birth_date, phone, address)
@@ -9,7 +9,15 @@
     </insert>
 
     <select id="findById" resultType="Customer">
-        SELECT customer_id, username, name, email, birth_date, phone, address, created_datetime, updated_datetime
+        SELECT customer_id,
+               username,
+               name,
+               email,
+               birth_date,
+               phone,
+               address,
+               created_datetime,
+               updated_datetime
         FROM customer
         WHERE customer_id = #{customerId}
     </select>

--- a/src/main/resources/mapper/PerformanceMapper.xml
+++ b/src/main/resources/mapper/PerformanceMapper.xml
@@ -47,7 +47,7 @@
                       ON p.performance_id = s.performance_id
                  JOIN reservation AS r
                       ON r.schedule_id = s.schedule_id
-        where p.performance_id = ${performanceId}
+        WHERE p.performance_id = ${performanceId}
         LIMIT #{pageable.offset}, #{pageable.size}
     </select>
 

--- a/src/main/resources/mapper/PerformanceMapper.xml
+++ b/src/main/resources/mapper/PerformanceMapper.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.programmers.ticketparis.mapper.PerformanceMapper">
+<mapper namespace="com.programmers.ticketparis.repository.performance.PerformanceMapper">
 
     <insert id="save" useGeneratedKeys="true" keyProperty="performanceId">
         INSERT INTO performance (title, poster_url, start_date, end_date, duration,
@@ -23,8 +23,8 @@
             price       = #{updateRequest.price},
             category    = #{updateRequest.category},
             description = #{updateRequest.description},
-            hall_Id = #{updateRequest.hallId}
-            WHERE performance_id = #{performanceId}
+            hall_Id     = #{updateRequest.hallId}
+        WHERE performance_id = #{performanceId}
 
     </update>
 
@@ -34,10 +34,26 @@
         WHERE performance_id = #{performanceId}
     </select>
 
-    <select id="findAll" resultType="Performance">
+    <select id="findPerformancesByPage" resultType="Performance">
         SELECT *
         FROM performance
+        LIMIT #{skipData}, #{size}
     </select>
+
+    <select id="findReservationsByPerformanceIdWithPage" resultMap="resultReservation">
+        SELECT r.reservation_id, r.status, r.created_datetime, r.updated_datetime, r.customer_id, r.schedule_id
+        FROM performance AS p
+                 JOIN schedule AS s
+                      ON p.performance_id = s.performance_id
+                 JOIN reservation AS r
+                      ON r.schedule_id = s.schedule_id
+        where p.performance_id = ${performanceId}
+        LIMIT #{pageable.skipData}, #{pageable.size}
+    </select>
+
+    <resultMap id="resultReservation" type="Reservation">
+        <result column="status" property="reservationStatus"/>
+    </resultMap>
 
     <select id="existsById" resultType="Boolean">
         SELECT EXISTS(select 1 from performance where performance_id = #{performanceId})

--- a/src/main/resources/mapper/PerformanceMapper.xml
+++ b/src/main/resources/mapper/PerformanceMapper.xml
@@ -37,7 +37,7 @@
     <select id="findPerformancesByPage" resultType="Performance">
         SELECT *
         FROM performance
-        LIMIT #{skipData}, #{size}
+        LIMIT #{offset}, #{size}
     </select>
 
     <select id="findReservationsByPerformanceIdWithPage" resultMap="resultReservation">
@@ -48,7 +48,7 @@
                  JOIN reservation AS r
                       ON r.schedule_id = s.schedule_id
         where p.performance_id = ${performanceId}
-        LIMIT #{pageable.skipData}, #{pageable.size}
+        LIMIT #{pageable.offset}, #{pageable.size}
     </select>
 
     <resultMap id="resultReservation" type="Reservation">

--- a/src/main/resources/mapper/ReservationMapper.xml
+++ b/src/main/resources/mapper/ReservationMapper.xml
@@ -25,7 +25,7 @@
     <select id="findReservationsByPage" resultMap="resultReservation">
         SELECT reservation_id, status, created_datetime, updated_datetime, customer_id, schedule_id
         FROM reservation
-        LIMIT #{skipData}, #{size};
+        LIMIT #{offset}, #{size};
     </select>
 
     <resultMap id="resultReservation" type="Reservation">

--- a/src/main/resources/mapper/ReservationMapper.xml
+++ b/src/main/resources/mapper/ReservationMapper.xml
@@ -22,9 +22,10 @@
         WHERE reservation_id = #{reservationId};
     </select>
 
-    <select id="findAll" resultMap="resultReservation">
+    <select id="findReservationsByPage" resultMap="resultReservation">
         SELECT reservation_id, status, created_datetime, updated_datetime, customer_id, schedule_id
-        FROM reservation;
+        FROM reservation
+        LIMIT #{skipData}, #{size};
     </select>
 
     <resultMap id="resultReservation" type="Reservation">

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -50,8 +50,8 @@
         FROM schedule AS s
                  JOIN reservation AS r
                       ON s.schedule_id = r.schedule_id
-        WHERE s.schedule_id = ${scheduleId} LIMIT #{pageable.offset}
-            , #{pageable.size};
+        WHERE s.schedule_id = ${scheduleId}
+        LIMIT #{pageable.offset}, #{pageable.size};
     </select>
 
     <resultMap id="resultReservation" type="Reservation">

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -47,4 +47,13 @@
     </select>
 >>>>>>> 4c981f4 (feat: 스케줄 도메인 오프셋 기반 페이지네이션 적용)
 
+    <select id="findReservationsByScheduleIdWithPage" resultType="Reservation">
+        SELECT r.reservation_id, r.status, r.created_datetime, r.updated_datetime, r.customer_id, r.schedule_id
+        FROM schedule AS s
+                 JOIN reservation AS r
+                      ON s.schedule_id = r.schedule_id
+        WHERE s.schedule_id = ${scheduleId} LIMIT #{pageable.skipData}
+            , #{pageable.size};
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -34,10 +34,17 @@
         WHERE schedule_id = #{scheduleId};
     </delete>
 
+<<<<<<< HEAD
     <update id="updateSeatsCountById">
         UPDATE schedule
         SET seats_count = #{seatsCount}
         WHERE schedule_id = #{scheduleId}
     </update>
+=======
+    <select id="findSchedulesByPage" resultType="Schedule">
+        SELECT schedule_id, start_datetime, sequence, seats_count, performance_id
+        FROM schedule LIMIT #{skipData}, #{size};
+    </select>
+>>>>>>> 4c981f4 (feat: 스케줄 도메인 오프셋 기반 페이지네이션 적용)
 
 </mapper>

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -34,20 +34,18 @@
         WHERE schedule_id = #{scheduleId};
     </delete>
 
-<<<<<<< HEAD
     <update id="updateSeatsCountById">
         UPDATE schedule
         SET seats_count = #{seatsCount}
         WHERE schedule_id = #{scheduleId}
     </update>
-=======
+
     <select id="findSchedulesByPage" resultType="Schedule">
         SELECT schedule_id, start_datetime, sequence, seats_count, performance_id
         FROM schedule LIMIT #{skipData}, #{size};
     </select>
->>>>>>> 4c981f4 (feat: 스케줄 도메인 오프셋 기반 페이지네이션 적용)
 
-    <select id="findReservationsByScheduleIdWithPage" resultType="Reservation">
+    <select id="findReservationsByScheduleIdWithPage" resultMap="resultReservation">
         SELECT r.reservation_id, r.status, r.created_datetime, r.updated_datetime, r.customer_id, r.schedule_id
         FROM schedule AS s
                  JOIN reservation AS r
@@ -55,5 +53,9 @@
         WHERE s.schedule_id = ${scheduleId} LIMIT #{pageable.skipData}
             , #{pageable.size};
     </select>
+
+    <resultMap id="resultReservation" type="Reservation">
+        <result column="status" property="reservationStatus"/>
+    </resultMap>
 
 </mapper>

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -42,7 +42,7 @@
 
     <select id="findSchedulesByPage" resultType="Schedule">
         SELECT schedule_id, start_datetime, sequence, seats_count, performance_id
-        FROM schedule LIMIT #{skipData}, #{size};
+        FROM schedule LIMIT #{offset}, #{size};
     </select>
 
     <select id="findReservationsByScheduleIdWithPage" resultMap="resultReservation">
@@ -50,7 +50,7 @@
         FROM schedule AS s
                  JOIN reservation AS r
                       ON s.schedule_id = r.schedule_id
-        WHERE s.schedule_id = ${scheduleId} LIMIT #{pageable.skipData}
+        WHERE s.schedule_id = ${scheduleId} LIMIT #{pageable.offset}
             , #{pageable.size};
     </select>
 

--- a/src/main/resources/mapper/SellerMapper.xml
+++ b/src/main/resources/mapper/SellerMapper.xml
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.programmers.ticketparis.mapper.member.SellerMapper">
+<mapper namespace="com.programmers.ticketparis.repository.member.SellerMapper">
 
     <insert id="save" useGeneratedKeys="true" keyProperty="sellerId">
         INSERT INTO seller (username, password, name, email, phone, registration_number, store_name)
         VALUES (#{username}, #{password}, #{name}, #{email}, #{phone}, #{registrationNumber}, #{storeName})
     </insert>
-    
+
     <select id="findById" resultType="Seller">
-        SELECT seller_id, username, name, email, phone, registration_number, store_name, created_datetime, updated_datetime
+        SELECT seller_id,
+               username,
+               name,
+               email,
+               phone,
+               registration_number,
+               store_name,
+               created_datetime,
+               updated_datetime
         FROM seller
         WHERE seller_id = #{sellerId}
     </select>
@@ -19,7 +27,11 @@
     </select>
 
     <select id="existsByUniqueFields" resultType="Boolean">
-        SELECT EXISTS(select 1 from seller where username = #{username} OR email = #{email} OR registration_number = #{registrationNumber})
+        SELECT EXISTS(select 1
+                      from seller
+                      where username = #{username}
+                         OR email = #{email}
+                         OR registration_number = #{registrationNumber})
     </select>
 
 </mapper>

--- a/src/test/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepositoryTest.java
+++ b/src/test/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepositoryTest.java
@@ -1,20 +1,28 @@
 package com.programmers.ticketparis.repository.performance;
 
-import com.programmers.ticketparis.domain.performance.Category;
-import com.programmers.ticketparis.domain.performance.Performance;
-import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
-import com.programmers.ticketparis.exception.ExceptionRule;
-import com.programmers.ticketparis.exception.PerformanceException;
-import org.junit.jupiter.api.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.domain.performance.Category;
+import com.programmers.ticketparis.domain.performance.Performance;
+import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
+import com.programmers.ticketparis.exception.ExceptionRule;
+import com.programmers.ticketparis.exception.PerformanceException;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -31,32 +39,32 @@ class MybatisPerformanceRepositoryTest {
     @BeforeAll
     void setUp() {
         testPerformance1 = Performance.builder()
-                .title("테스트 공연 타이틀")
-                .posterUrl("http://www.kopis.or.kr/upload/pfmPoster/PF_PF224812_230829_130237.gif")
-                .startDate(LocalDate.of(2023, 9, 11))
-                .endDate(LocalDate.of(2023, 12, 31))
-                .duration("2시간")
-                .price(15000)
-                .ageRating(15)
-                .category(Category.MUSICAL)
-                .description("테스트 공연 상세 설명")
-                .sellerId(1L)
-                .hallId(1L)
-                .build();
+            .title("테스트 공연 타이틀")
+            .posterUrl("http://www.kopis.or.kr/upload/pfmPoster/PF_PF224812_230829_130237.gif")
+            .startDate(LocalDate.of(2023, 9, 11))
+            .endDate(LocalDate.of(2023, 12, 31))
+            .duration("2시간")
+            .price(15000)
+            .ageRating(15)
+            .category(Category.MUSICAL)
+            .description("테스트 공연 상세 설명")
+            .sellerId(1L)
+            .hallId(1L)
+            .build();
 
         testPerformance2 = Performance.builder()
-                .title("테스트 공연 타이틀")
-                .posterUrl("http://www.kopis.or.kr/upload/pfmPoster/PF_PF224812_230829_130237.gif")
-                .startDate(LocalDate.of(2023, 10, 11))
-                .endDate(LocalDate.of(2023, 12, 19))
-                .duration("3시간")
-                .price(30000)
-                .ageRating(15)
-                .category(Category.MUSICAL)
-                .description("테스트 공연 상세 설명")
-                .sellerId(1L)
-                .hallId(1L)
-                .build();
+            .title("테스트 공연 타이틀")
+            .posterUrl("http://www.kopis.or.kr/upload/pfmPoster/PF_PF224812_230829_130237.gif")
+            .startDate(LocalDate.of(2023, 10, 11))
+            .endDate(LocalDate.of(2023, 12, 19))
+            .duration("3시간")
+            .price(30000)
+            .ageRating(15)
+            .category(Category.MUSICAL)
+            .description("테스트 공연 상세 설명")
+            .sellerId(1L)
+            .hallId(1L)
+            .build();
     }
 
     @Transactional
@@ -69,8 +77,8 @@ class MybatisPerformanceRepositoryTest {
 
         //then
         Performance savePerformance = mybatisPerformanceRepository.findById(savedPerformanceId)
-                .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
-                        List.of(String.valueOf(savedPerformanceId))));
+            .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
+                List.of(String.valueOf(savedPerformanceId))));
 
         assertThat(savePerformance).isNotNull();
     }
@@ -84,8 +92,8 @@ class MybatisPerformanceRepositoryTest {
 
         //when
         Performance foundPerformance = mybatisPerformanceRepository.findById(findPerformanceById)
-                .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
-                        List.of(String.valueOf(findPerformanceById))));
+            .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
+                List.of(String.valueOf(findPerformanceById))));
 
         //then
         assertThat(foundPerformance).isNotNull();
@@ -99,8 +107,13 @@ class MybatisPerformanceRepositoryTest {
         mybatisPerformanceRepository.save(testPerformance1);
         mybatisPerformanceRepository.save(testPerformance2);
 
+        Pageable pageable = Pageable.builder()
+            .pageNum(1)
+            .size(10)
+            .build();
+
         //when
-        List<Performance> performances = mybatisPerformanceRepository.findAll();
+        List<Performance> performances = mybatisPerformanceRepository.findPerformancesByPage(pageable);
 
         //then
         assertThat(performances).isNotNull();
@@ -115,24 +128,24 @@ class MybatisPerformanceRepositoryTest {
         //given
         Long savedPerformanceId = mybatisPerformanceRepository.save(testPerformance1);
         PerformanceUpdateRequest performanceUpdateRequest = new PerformanceUpdateRequest(
-                "수정된 타이틀",
-                "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
-                LocalDate.of(2023, 9, 11),
-                LocalDate.of(2023, 11, 13),
-                "3시간",
-                15,
-                30000,
-                Category.MUSICAL,
-                "테스트 설명입니다.",
-                1L);
+            "수정된 타이틀",
+            "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
+            LocalDate.of(2023, 9, 11),
+            LocalDate.of(2023, 11, 13),
+            "3시간",
+            15,
+            30000,
+            Category.MUSICAL,
+            "테스트 설명입니다.",
+            1L);
 
         //when
         mybatisPerformanceRepository.update(savedPerformanceId, performanceUpdateRequest);
 
         //then
         Performance updatedPerformance = mybatisPerformanceRepository.findById(savedPerformanceId)
-                .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
-                        List.of(String.valueOf(savedPerformanceId))));
+            .orElseThrow(() -> new PerformanceException(ExceptionRule.PERFORMANCE_NOT_EXIST,
+                List.of(String.valueOf(savedPerformanceId))));
 
         assertThat(updatedPerformance.getTitle()).isEqualTo(performanceUpdateRequest.getTitle());
     }

--- a/src/test/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepositoryTest.java
+++ b/src/test/java/com/programmers/ticketparis/repository/performance/MybatisPerformanceRepositoryTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Category;
 import com.programmers.ticketparis.domain.performance.Performance;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/test/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepositoryTest.java
+++ b/src/test/java/com/programmers/ticketparis/repository/reservation/MybatisReservationRepositoryTest.java
@@ -72,8 +72,7 @@ class MybatisReservationRepositoryTest {
 
         // then
         ReservationStatus actualReservationStatus = reservationRepository.findById(reservationId)
-            .orElseThrow(() -> new ReservationException(RESERVATION_NOT_EXIST, reservationId))
-            .getReservationStatus();
+            .orElseThrow(() -> new ReservationException(RESERVATION_NOT_EXIST, reservationId)).getReservationStatus();
 
         assertThat(actualReservationStatus).isEqualTo(ReservationStatus.CANCELED);
     }

--- a/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
+++ b/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
@@ -93,7 +93,12 @@ class PerformanceServiceTest {
     @DisplayName("저장된 모든 공연을 조회한다.")
     void findAllPerformanceTest() {
         //given & when
-        List<PerformanceResponse> performances = performanceService.findAllPerformances();
+        Pageable pageable = Pageable.builder()
+            .pageNum(1)
+            .size(10)
+            .build();
+
+        List<PerformanceResponse> performances = performanceService.findPerformancesByPage(pageable);
 
         //then
         assertFalse(performances.isEmpty());

--- a/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
+++ b/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.programmers.ticketparis.domain.pageable.Pageable;
+import com.programmers.ticketparis.common.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Category;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;

--- a/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
+++ b/src/test/java/com/programmers/ticketparis/service/performance/PerformanceServiceTest.java
@@ -1,5 +1,22 @@
 package com.programmers.ticketparis.service.performance;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.programmers.ticketparis.domain.pageable.Pageable;
 import com.programmers.ticketparis.domain.performance.Category;
 import com.programmers.ticketparis.dto.performance.request.PerformanceCreateRequest;
 import com.programmers.ticketparis.dto.performance.request.PerformanceUpdateRequest;
@@ -8,15 +25,6 @@ import com.programmers.ticketparis.dto.performance.response.PerformanceResponse;
 import com.programmers.ticketparis.exception.ExceptionRule;
 import com.programmers.ticketparis.exception.PerformanceException;
 import com.programmers.ticketparis.repository.performance.MybatisPerformanceRepository;
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -35,29 +43,29 @@ class PerformanceServiceTest {
     @BeforeAll
     void setUp() {
         performanceCreateRequest = new PerformanceCreateRequest(
-                "제4회 더 싱어즈 정기연주회",
-                "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
-                LocalDate.of(2023, 9, 20),
-                LocalDate.of(2023, 12, 20),
-                "2시간",
-                15,
-                15000,
-                Category.MUSICAL,
-                "테스트 공연 입니다.",
-                1L,
-                1L);
+            "제4회 더 싱어즈 정기연주회",
+            "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
+            LocalDate.of(2023, 9, 20),
+            LocalDate.of(2023, 12, 20),
+            "2시간",
+            15,
+            15000,
+            Category.MUSICAL,
+            "테스트 공연 입니다.",
+            1L,
+            1L);
 
         performanceUpdateRequest = new PerformanceUpdateRequest(
-                "수정된 타이틀",
-                "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
-                LocalDate.of(2023, 9, 11),
-                LocalDate.of(2023, 11, 13),
-                "3시간",
-                15,
-                30000,
-                Category.MUSICAL,
-                "테스트 설명입니다.",
-                1L);
+            "수정된 타이틀",
+            "http://www.kopis.or.kr/upload/pfmPoster/PF_PF224754_230828_165705.gif",
+            LocalDate.of(2023, 9, 11),
+            LocalDate.of(2023, 11, 13),
+            "3시간",
+            15,
+            30000,
+            Category.MUSICAL,
+            "테스트 설명입니다.",
+            1L);
     }
 
     @Transactional
@@ -114,11 +122,13 @@ class PerformanceServiceTest {
         Long performanceId = 6L;
 
         //when
-        PerformanceIdResponse updatedPerformanceIdResponse = performanceService.updatePerformance(performanceId, performanceUpdateRequest);
+        PerformanceIdResponse updatedPerformanceIdResponse = performanceService.updatePerformance(performanceId,
+            performanceUpdateRequest);
 
         //then
         assertNotNull(updatedPerformanceIdResponse);
-        PerformanceResponse updatedPerformance = performanceService.findPerformanceById(updatedPerformanceIdResponse.getPerformanceId());
+        PerformanceResponse updatedPerformance = performanceService.findPerformanceById(
+            updatedPerformanceIdResponse.getPerformanceId());
         assertEquals(performanceUpdateRequest.getTitle(), updatedPerformance.getTitle());
     }
 
@@ -129,7 +139,7 @@ class PerformanceServiceTest {
     void deletePerformanceByIdTest() {
         //given
         Long performanceId = 6L;
-        
+
         //when
         performanceService.deletePerformanceById(performanceId);
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #39**

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 비지니스 로직 상 공연 별 예매 내역, 스케줄 별 예매 내역 그리고 전체 예매 내역을 가져올 때 **예매 데이터는 굉장히 많으므로** 페이지네이션 처리를 해야함.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 전체 예매 내역 페이지네이션
- [X] 스케줄 별 예매 내역 페이지네이션
- [X] 스케줄 조회 페이지 네이션
- [X] 공연 별 예매 내역 페이지네이션
- [X] 공연 조회 페이지 네이션

---

### 🙏 리뷰어에게
- 예매, 스케줄, 공연 도메인에 대해서 각 도메인의 전체 조회를 페이지네이션으로 변경하였습니다.
- 스케줄, 공연 도메인에 대해서 각 도메인 별 예매 내역을 페이지네이션 처리했습니다.

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
