### PR TITLE
[#35] (인증, 인가) 비밀번호 암호화 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
+    implementation 'org.mindrot:jbcrypt:0.4'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/programmers/ticketparis/domain/member/Customer.java
+++ b/src/main/java/com/programmers/ticketparis/domain/member/Customer.java
@@ -3,6 +3,8 @@ package com.programmers.ticketparis.domain.member;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.mindrot.jbcrypt.BCrypt;
+
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,7 +45,7 @@ public class Customer {
     private Customer(String username, String password, String name, String email, LocalDate birthDate, String phone,
         String address) {
         this.username = username;
-        this.password = password;
+        this.password = BCrypt.hashpw(password, BCrypt.gensalt());
         this.name = name;
         this.email = email;
         this.birthDate = birthDate;

--- a/src/test/java/com/programmers/ticketparis/domain/member/CustomerTest.java
+++ b/src/test/java/com/programmers/ticketparis/domain/member/CustomerTest.java
@@ -1,0 +1,33 @@
+package com.programmers.ticketparis.domain.member;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+class CustomerTest {
+
+    @Test
+    @DisplayName("구매자를 생성할 때 비밀번호가 암호화 된다")
+    void encodePassword() {
+        //given
+        String password = "dkssudfd12!";
+
+        //when
+        Customer customer = Customer.builder()
+            .username("dksadftlsr")
+            .password(password)
+            .name("이현현")
+            .email("abcsu@naver.com")
+            .birthDate(LocalDate.parse("1997-03-27"))
+            .phone("010-1111-2222")
+            .address("성신여대")
+            .build();
+
+        //then
+        assertThat(BCrypt.checkpw(password, BCrypt.hashpw(password, BCrypt.gensalt()))).isTrue();
+    }
+}

--- a/src/test/java/com/programmers/ticketparis/repository/member/MyBatisCustomerRepositoryTest.java
+++ b/src/test/java/com/programmers/ticketparis/repository/member/MyBatisCustomerRepositoryTest.java
@@ -84,5 +84,4 @@ class MyBatisCustomerRepositoryTest {
         assertThat(actualCustomer.getPhone()).isEqualTo("010-1234-5678");
         assertThat(actualCustomer.getBirthDate()).isEqualTo("1990-01-01");
     }
-
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,11 +4,8 @@ spring:
     url: jdbc:h2:mem:ticketparis
     username: sa
 
-# MyBatis 설정
 mybatis:
-  # 마이바티스에서 타입 정보를 사용할 때 패키지 이름을 적어줘야하는데, 여기에 명시하면 패키지 이름 생략 가능
   type-aliases-package: com.programmers.ticketparis.domain
-  # underscore를 camel-case 자동 변환
   configuration:
     map-underscore-to-camel-case: true
   mapper-locations: classpath:mapper/**/*.xml

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,8 +4,11 @@ spring:
     url: jdbc:h2:mem:ticketparis
     username: sa
 
+# MyBatis 설정
 mybatis:
+  # 마이바티스에서 타입 정보를 사용할 때 패키지 이름을 적어줘야하는데, 여기에 명시하면 패키지 이름 생략 가능
   type-aliases-package: com.programmers.ticketparis.domain
+  # underscore를 camel-case 자동 변환
   configuration:
     map-underscore-to-camel-case: true
   mapper-locations: classpath:mapper/**/*.xml


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #35**

### 📑 PR 개요
bcrypt 라이브러리를 활용한 비밀번호 암호화 기능 구현

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] bcypt 라이브러리를 활용한 비밀번호 암호화

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- bcrypt를 활용하여 암호화하는 방법에는 두 가지가 있는데요. 하나는 스프링 시큐리티 의존성을 추가하여 내장 클래스를 이용하는 방법이고, 다른 하나는 간단하게 Bcrypt 라이브러리를 추가하는 방법입니다. 전자는 시큐리티의 기본 기능들을 비활성화하는 등 여러 설정이 필요하고, 불필요하게 큰 의존성이 추가될 필요가 없다고 생각되어서 간단한 라이브러리로 구현해보았습니다.

- 암호화 적용 시점은 Customer 도메인이 생성될 때로 잡았습니다. 생성자 안에서 비밀번호를 암호화한 뒤, 생성되는 방식입니다.

---


### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
