### PR TITLE
[#54] 단순 전체 랭킹 조회 기능

### DIFF
--- a/src/main/java/com/programmers/ticketparis/controller/ranking/RankingController.java
+++ b/src/main/java/com/programmers/ticketparis/controller/ranking/RankingController.java
@@ -1,0 +1,29 @@
+package com.programmers.ticketparis.controller.ranking;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.programmers.ticketparis.dto.ApiResponse;
+import com.programmers.ticketparis.dto.ranking.response.RankingResponse;
+import com.programmers.ticketparis.service.ranking.RankingService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ranking")
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @GetMapping
+    public ApiResponse<List<RankingResponse>> findTopRankings(HttpServletRequest httpServletRequest) {
+        List<RankingResponse> rankingResponses = rankingService.findTopRankings();
+
+        return ApiResponse.of(httpServletRequest.getRequestURI(), rankingResponses);
+    }
+}

--- a/src/main/java/com/programmers/ticketparis/dto/ranking/response/RankingResponse.java
+++ b/src/main/java/com/programmers/ticketparis/dto/ranking/response/RankingResponse.java
@@ -1,0 +1,21 @@
+package com.programmers.ticketparis.dto.ranking.response;
+
+import java.time.LocalDate;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingResponse {
+
+    private Long performanceId;
+    private String title;
+    private String posterUrl;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String hallName;
+    private Double reservationRate;
+    private Integer ranking;
+}

--- a/src/main/java/com/programmers/ticketparis/repository/ranking/MybatisRankingRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/ranking/MybatisRankingRepository.java
@@ -1,0 +1,21 @@
+package com.programmers.ticketparis.repository.ranking;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.programmers.ticketparis.dto.ranking.response.RankingResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisRankingRepository implements RankingRepository {
+
+    private final RankingMapper rankingMapper;
+
+    @Override
+    public List<RankingResponse> findTopRankings() {
+        return rankingMapper.findTopRankings();
+    }
+}

--- a/src/main/java/com/programmers/ticketparis/repository/ranking/RankingMapper.java
+++ b/src/main/java/com/programmers/ticketparis/repository/ranking/RankingMapper.java
@@ -1,0 +1,13 @@
+package com.programmers.ticketparis.repository.ranking;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.programmers.ticketparis.dto.ranking.response.RankingResponse;
+
+@Mapper
+public interface RankingMapper {
+
+    List<RankingResponse> findTopRankings();
+}

--- a/src/main/java/com/programmers/ticketparis/repository/ranking/RankingRepository.java
+++ b/src/main/java/com/programmers/ticketparis/repository/ranking/RankingRepository.java
@@ -1,0 +1,10 @@
+package com.programmers.ticketparis.repository.ranking;
+
+import java.util.List;
+
+import com.programmers.ticketparis.dto.ranking.response.RankingResponse;
+
+public interface RankingRepository {
+
+    List<RankingResponse> findTopRankings();
+}

--- a/src/main/java/com/programmers/ticketparis/service/ranking/RankingService.java
+++ b/src/main/java/com/programmers/ticketparis/service/ranking/RankingService.java
@@ -1,0 +1,21 @@
+package com.programmers.ticketparis.service.ranking;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.programmers.ticketparis.dto.ranking.response.RankingResponse;
+import com.programmers.ticketparis.repository.ranking.RankingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+
+    public List<RankingResponse> findTopRankings() {
+        return rankingRepository.findTopRankings();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,7 @@ spring:
 # MyBatis 설정
 mybatis:
   # 마이바티스에서 타입 정보를 사용할 때 패키지 이름을 적어줘야하는데, 여기에 명시하면 패키지 이름 생략 가능
-  type-aliases-package: com.programmers.ticketparis.domain
-
+  type-aliases-package: com.programmers.ticketparis.domain, com.programmers.ticketparis.dto
   # underscore를 camel-case 자동 변환
   configuration:
     map-underscore-to-camel-case: true

--- a/src/main/resources/mapper/RankingMapper.xml
+++ b/src/main/resources/mapper/RankingMapper.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.programmers.ticketparis.repository.ranking.RankingMapper">
+
+    <select id="findTopRankings" resultType="RankingResponse">
+        SELECT
+            performance_id,
+            title,
+            poster_url,
+            start_date,
+            end_date,
+            hall_name,
+            reservation_rate,
+            RANK() OVER (ORDER BY reservation_rate DESC) ranking
+
+        FROM (
+            SELECT
+                p.performance_id performance_id,
+                p.title title,
+                p.poster_url poster_url,
+                p.start_date start_date,
+                p.end_date end_date,
+                h.name hall_name,
+                ROUND((1 - (s.remaining_seats_count / CAST((h.seats_count * s.schedules_count) AS DOUBLE))) * 100, 1)
+                    AS reservation_rate
+
+            FROM performance p
+
+            JOIN hall h
+            ON p.hall_id = h.hall_id
+
+            JOIN (
+                SELECT
+                    performance_id,
+                    COUNT(schedule_id) schedules_count,
+                    SUM(seats_count) remaining_seats_count
+                FROM schedule
+                GROUP BY performance_id
+            ) s
+            ON p.performance_id = s.performance_id
+        ) r
+
+        ORDER BY ranking, title
+        LIMIT 50;
+    </select>
+
+</mapper>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,7 +11,7 @@ spring:
       password: ${REDIS_PASSWORD}
 
 mybatis:
-  type-aliases-package: com.programmers.ticketparis.domain
+  type-aliases-package: com.programmers.ticketparis.domain, com.programmers.ticketparis.dto
   configuration:
     map-underscore-to-camel-case: true
   mapper-locations: classpath:mapper/**/*.xml


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #54**

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 전체 공연에 대한 예매율 정렬
  - 예매율이 같으면 사전 순 이름으로 2차 정렬
  - 상위 50개의 공연만 표시
  - 랭킹이 같으면 같은 순위로 표시하고 겹치는 순위 개수만큼 다음 순위 뛰어넘기 (ex. `1위 2위 2위 4위`)
- `전체 좌석 수` = 스케줄 수 * 공연장 좌석 수
- `잔여 좌석 수` = 하나의 공연 당 모든 스케줄의 잔여 좌석 수의 합
- `예매율` = (1 - (잔여 좌석 수 / 전체 좌석 수)) * 100 (단, 반올림하여 소수점 1의 자리까지 표시)
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 예매 및 좌석수 조합하여 판매순 알고리즘 작성
- [x] 단순 전체 랭킹 조회 api 작성

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 조인과 서브쿼리를 이용해서 SQL이 조금 복잡하네요. 더 효율적인 SQL문이 되도록 많은 피드백 부탁드립니다..ㅎㅎ

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
