### PR TITLE
[#61] 공연 예매, 예매 취소에 대한 비관적 락 적용

### DIFF
--- a/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
+++ b/src/main/java/com/programmers/ticketparis/common/exception/ExceptionRule.java
@@ -23,6 +23,7 @@ public enum ExceptionRule {
 
     RESERVATION_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 예매를 찾을 수 없음"),
     RESERVATION_STATUS_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "올바르지 않은 예매 상태"),
+    RESERVATION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "해당하는 예매는 이미 취소된 상태"),
 
     SCHEDULE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 스케줄을 찾을 수 없음"),
     SCHEDULE_NO_SEATS(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 스케줄의 남은 좌석 수가 없음"),

--- a/src/main/java/com/programmers/ticketparis/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/schedule/repository/ScheduleRepository.java
@@ -15,6 +15,8 @@ public interface ScheduleRepository {
 
     Optional<Schedule> findById(Long scheduleId);
 
+    Optional<Schedule> findByIdWithPessimisticLock(Long scheduleId);
+
     Boolean existsById(Long scheduleId);
 
     Integer deleteById(Long scheduleId);

--- a/src/main/java/com/programmers/ticketparis/schedule/repository/mapper/ScheduleMapper.java
+++ b/src/main/java/com/programmers/ticketparis/schedule/repository/mapper/ScheduleMapper.java
@@ -27,4 +27,6 @@ public interface ScheduleMapper {
     List<Schedule> findSchedulesByPage(Pageable pageable);
 
     List<Reservation> findReservationsByScheduleIdWithPage(Integer scheduleId, Pageable pageable);
+
+    Optional<Schedule> findByIdWithPessimisticLock(Long scheduleId);
 }

--- a/src/main/java/com/programmers/ticketparis/schedule/repository/mybatis/MybatisScheduleRepository.java
+++ b/src/main/java/com/programmers/ticketparis/schedule/repository/mybatis/MybatisScheduleRepository.java
@@ -37,6 +37,11 @@ public class MybatisScheduleRepository implements ScheduleRepository {
     }
 
     @Override
+    public Optional<Schedule> findByIdWithPessimisticLock(Long scheduleId) {
+        return scheduleMapper.findByIdWithPessimisticLock(scheduleId);
+    }
+
+    @Override
     public Boolean existsById(Long scheduleId) {
         return scheduleMapper.existsById(scheduleId);
     }

--- a/src/main/java/com/programmers/ticketparis/schedule/service/ScheduleService.java
+++ b/src/main/java/com/programmers/ticketparis/schedule/service/ScheduleService.java
@@ -43,6 +43,11 @@ public class ScheduleService {
             .orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_EXIST, scheduleId));
     }
 
+    public Schedule findByIdWithPessimisticLock(Long scheduleId) {
+        return scheduleRepository.findByIdWithPessimisticLock(scheduleId)
+            .orElseThrow(() -> new ScheduleException(SCHEDULE_NOT_EXIST, scheduleId));
+    }
+
     @Transactional
     public void deleteScheduleById(Long scheduleId) {
         if (!scheduleRepository.existsById(scheduleId)) {

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.programmers.ticketparis.schedule.repository.mapper.ScheduleMapper">
-
     <insert id="save" useGeneratedKeys="true" keyProperty="scheduleId">
         INSERT INTO schedule (start_datetime, sequence, seats_count, performance_id)
         VALUES (#{startDatetime}, #{sequence}, #{seatsCount}, #{performanceId});
@@ -31,6 +30,13 @@
         FROM schedule
         WHERE schedule_id = #{scheduleId};
     </delete>
+
+    <select id="findByIdWithPessimisticLock" resultType="Schedule">
+        SELECT schedule_id, start_datetime, sequence, seats_count, performance_id, created_datetime, updated_datetime
+        FROM schedule
+        WHERE schedule_id = #{scheduleId}
+        FOR UPDATE;
+    </select>
 
     <update id="updateSeatsCountById">
         UPDATE schedule

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
@@ -1,0 +1,100 @@
+package com.programmers.ticketparis.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.programmers.ticketparis.reservation.dto.request.ReservationCreateRequest;
+import com.programmers.ticketparis.schedule.domain.Schedule;
+import com.programmers.ticketparis.schedule.service.ScheduleService;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ReservationPessimisticTest {
+
+    private static ReservationCreateRequest reservationCreateRequest;
+    private static int seatsCount;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @BeforeAll
+    void setUp() {
+        reservationCreateRequest = ReservationCreateRequest.builder()
+            .customerId(1L)
+            .scheduleId(1L)
+            .build();
+
+        seatsCount = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId()).getSeatsCount();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("고객 100명이 동시에 예약을 한다.")
+    void concurrentReservationBy100Users_Success() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    reservationService.createReservation(reservationCreateRequest);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
+
+        assertThat(schedule.getSeatsCount()).isEqualTo(seatsCount - 100);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("고객 100명이 동시에 예약 취소한다.")
+    void concurrentReservationCancelBy100Users_Success() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        /**
+         * 테스트시 필요한 더미 데이터 이후의 ID 값부터 시작
+         * 예약번호 19번 부터 예매를 취소
+         */
+        for (int i = 19; i <= threadCount + 18; i++) {
+            int threadNum = i;
+
+            executorService.submit(() -> {
+                try {
+                    reservationService.cancelReservationById(Long.valueOf(threadNum));
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
+
+        assertThat(schedule.getSeatsCount()).isEqualTo(seatsCount);
+    }
+
+}

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
@@ -25,6 +25,7 @@ class ReservationPessimisticTest {
 
     private static ReservationCreateRequest reservationCreateRequest;
     private static int seatsCount;
+    private static int reservationedSeatsCount;
 
     @Autowired
     private ReservationService reservationService;
@@ -65,7 +66,8 @@ class ReservationPessimisticTest {
 
         Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
 
-        assertThat(schedule.getSeatsCount()).isEqualTo(seatsCount - 100);
+        reservationedSeatsCount = schedule.getSeatsCount();
+        assertThat(reservationedSeatsCount).isEqualTo(seatsCount - 100);
     }
 
     @Test
@@ -97,7 +99,7 @@ class ReservationPessimisticTest {
 
         Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
 
-        assertThat(schedule.getSeatsCount()).isEqualTo(seatsCount);
+        assertThat(schedule.getSeatsCount()).isEqualTo(reservationedSeatsCount + threadCount);
     }
 
 }

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
@@ -6,26 +6,21 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.ticketparis.reservation.dto.request.ReservationCreateRequest;
 import com.programmers.ticketparis.schedule.domain.Schedule;
 import com.programmers.ticketparis.schedule.service.ScheduleService;
 
 @SpringBootTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ReservationPessimisticTest {
 
     private static ReservationCreateRequest reservationCreateRequest;
     private static int seatsCount;
-    private static int reservationedSeatsCount;
 
     @Autowired
     private ReservationService reservationService;
@@ -33,7 +28,7 @@ class ReservationPessimisticTest {
     @Autowired
     private ScheduleService scheduleService;
 
-    @BeforeAll
+    @BeforeEach
     void setUp() {
         reservationCreateRequest = ReservationCreateRequest.builder()
             .customerId(1L)
@@ -44,8 +39,6 @@ class ReservationPessimisticTest {
     }
 
     @Test
-    @Order(1)
-    @Transactional
     @DisplayName("고객 100명이 동시에 예약을 한다.")
     void concurrentReservationBy100Users_Success() throws InterruptedException {
         int threadCount = 100;
@@ -66,40 +59,6 @@ class ReservationPessimisticTest {
 
         Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
 
-        reservationedSeatsCount = schedule.getSeatsCount();
-        assertThat(reservationedSeatsCount).isEqualTo(seatsCount - 100);
+        assertThat(schedule.getSeatsCount()).isEqualTo(seatsCount - 100);
     }
-
-    @Test
-    @Order(2)
-    @Transactional
-    @DisplayName("고객 100명이 동시에 예약 취소한다.")
-    void concurrentReservationCancelBy100Users_Success() throws InterruptedException {
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(32);
-        CountDownLatch latch = new CountDownLatch(threadCount);
-
-        /**
-         * 테스트시 필요한 더미 데이터 이후의 ID 값부터 시작
-         * 예약번호 19번 부터 예매를 취소
-         */
-        for (int i = 19; i <= threadCount + 18; i++) {
-            int threadNum = i;
-
-            executorService.submit(() -> {
-                try {
-                    reservationService.cancelReservationById(Long.valueOf(threadNum));
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        latch.await();
-
-        Schedule schedule = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId());
-
-        assertThat(schedule.getSeatsCount()).isEqualTo(reservationedSeatsCount + threadCount);
-    }
-
 }

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
@@ -35,7 +35,8 @@ class ReservationPessimisticTest {
             .scheduleId(1L)
             .build();
 
-        seatsCount = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId()).getSeatsCount();
+        seatsCount = scheduleService.findByScheduleId(reservationCreateRequest.getScheduleId())
+            .getSeatsCount();
     }
 
     @Test

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationPessimisticTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.ticketparis.reservation.dto.request.ReservationCreateRequest;
 import com.programmers.ticketparis.schedule.domain.Schedule;
@@ -43,6 +44,7 @@ class ReservationPessimisticTest {
 
     @Test
     @Order(1)
+    @Transactional
     @DisplayName("고객 100명이 동시에 예약을 한다.")
     void concurrentReservationBy100Users_Success() throws InterruptedException {
         int threadCount = 100;
@@ -68,6 +70,7 @@ class ReservationPessimisticTest {
 
     @Test
     @Order(2)
+    @Transactional
     @DisplayName("고객 100명이 동시에 예약 취소한다.")
     void concurrentReservationCancelBy100Users_Success() throws InterruptedException {
         int threadCount = 100;

--- a/src/test/java/com/programmers/ticketparis/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/programmers/ticketparis/reservation/service/ReservationServiceTest.java
@@ -21,7 +21,7 @@ import com.programmers.ticketparis.reservation.dto.response.ReservationResponse;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ReservationServiceTest {
+class ReservationServiceTest {
 
     private static ReservationCreateRequest reservationCreateRequest1;
     private static ReservationCreateRequest reservationCreateRequest2;


### PR DESCRIPTION
## 👨‍💻 작업 사항

<!-- 이슈 번호 태그 -->
> **이슈 #61**

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 인터파크와 같은 티켓팅 사이트의 경우 동시 접속하여 티켓을 구매하는 경우가 많기 때문에 동시에 같은 레코드에 접근하여 업데이트하는 경우가 생기는데 이 때 생각했던 값과 다르게 반영되는 경우가 생김.
- 위 문제를 해결하기 위해 낙관적 락, 비관적 락, Redis를 사용하여 DB에 동시에 접근하는 것을 방지하거나, 애플리케이션 단계에서 순차적으로 업데이트시킬 수 있도록 구현이 필요.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 공연 예매에 대한 비관적 락 적용
- [X] 예매 취소에 대한 비관적 락 적용
- [X] 공연 예매에 대한 동시성 테스트 작성

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 낙관적 락의 경우 충돌을 최대한 피한다라는 개념으로 쓰이기 때문에 충돌이 많아지면 많아질 수록 성능 상에 이슈가 생깁니다. 그리고 스케일 아웃시 여러 개의 서버에서 동기화 하는 문제로 인해 DB 자체에 락을 거는 비관적 락을 사용해서 처리했습니다.
- 공연 예매, 예매 취소에 대해 Jmeter로 테스트해서 정상적으로 동작하는 것을 확인했습니다!

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
